### PR TITLE
fix: removes automatically setting height of iFrame

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -216,50 +216,6 @@ describe("Embed", () => {
     });
 
     describe("window dimensions change event", () => {
-      it("logs the event", () => {
-        fireEvent(
-          window,
-          new MessageEvent("message", {
-            data: {
-              kind: MESSAGE_KIND.WINDOW_DIMENSION_CHANGE,
-              data: {
-                bounds: {
-                  height: 200,
-                },
-              },
-            },
-            origin: "https://api.superapi.com.au",
-          }),
-        );
-
-        // eslint-disable-next-line @typescript-eslint/unbound-method
-        expect(loglevel.debug).toHaveBeenCalledWith(
-          "Reacting to dimensions change of iFrame element, setting height to 200",
-        );
-      });
-
-      it("sets the height of the iframe", () => {
-        fireEvent(
-          window,
-          new MessageEvent("message", {
-            data: {
-              kind: MESSAGE_KIND.WINDOW_DIMENSION_CHANGE,
-              data: {
-                bounds: {
-                  height: 200,
-                },
-              },
-            },
-            origin: "https://api.superapi.com.au",
-          }),
-        );
-
-        const scope = within(element);
-        const iframe = scope.getByTestId("iframe");
-        expect(iframe).toHaveAttribute("height", "200px");
-        expect(iframe).toHaveAttribute("width", "100%");
-      });
-
       it("calls externally bound listener", () => {
         const listener = jest.fn();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -162,17 +162,8 @@ export class Embed {
         break;
       }
 
-      // When the dimensions of the iFrames height change, we want to modify
-      // the containing element
       case MESSAGE_KIND.WINDOW_DIMENSION_CHANGE: {
-        const height = event.data.data.bounds.height;
-        log.debug(
-          `Reacting to dimensions change of iFrame element, setting height to ${height}`,
-        );
-        this.iframe.height = `${height}px`;
-
         this.bus.emit(event.data.kind, event.data.data);
-
         break;
       }
 


### PR DESCRIPTION
Instead of trying to maintain the height of the iframe automatically, delegate this to the third party code to interact with instead.

BREAKING CHANGE: If you were previously relying on the automatic height to (incorrectly) be set, this will now need to be done manually.
