### PR TITLE
feat(component layout): iFrame height defaults to contents height

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 npx lint-staged

--- a/README.md
+++ b/README.md
@@ -40,18 +40,13 @@ The `Embed` class can be invoked with the following parameters:
 | element             | The DOM node you want to place the embed into. Any content in this node will be removed                                                       | Yes      |         | `document.getElementById("myEmbed")` |
 | extraAllowedOrigins | By default the embed will only accept messages from origin https://api.superapi.com.au - if required, you can pass extra allowed origins here | Yes      |         | `['https://www.example.com']`        |
 | loaderClass         | An optional class that can be added to the loader element which is shown when the embed is initializing. Use this to customise the loader.    | No       |         | `.myLoader`                          |
-| matchContentsHeight | Should the iframe resize its height to match the contents of what is inside it?                                                               | No       | False   | `true`                               |
 | url                 | The SuperAPI URL that has been signed, this will then be loaded                                                                               | Yes      |         | `https://example.com`                |
 
 Once the loader has been setup you can then interact with returned instance of the embed.
 
 #### Embed height
 
-One thing to think about when using the embed with your system is where the responsibility of the height of the embed lies. We have two options here:
-
-1. The first option is that you control the height of the embed and it adapts. This is our preferred setup and if offers the most flexibility with the least amount of effort. Simply set the height of the embed to either a fixed or fluid height and we will take care of the rest.
-
-2. Your second option is to let us drive the height of the embed. To do this, turn on the `matchContentsHeight` option. This will instruct the embed to automatically resize the iFrame to match the contents. With this setting on, be sure to place the embed in a container with an overflow on it so that the user can scroll to see content that might be off the bottom of the page.
+The embed will automatically expand the iFrame to match the contents of what it is showing. If your layout has a fixed height, please place the iFrame in a container element with a style of `overflow-y: auto` to avoid the embed breaking your page layout.
 
 ### Events
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -269,28 +269,6 @@ describe("Embed", () => {
           );
         });
 
-        it("ignores setting the height of the iframe", () => {
-          fireEvent(
-            window,
-            new MessageEvent("message", {
-              data: {
-                kind: MESSAGE_KIND.WINDOW_DIMENSION_CHANGE,
-                data: {
-                  bounds: {
-                    height: 200,
-                  },
-                },
-              },
-              origin: "https://api.superapi.com.au",
-            }),
-          );
-
-          const scope = within(element);
-          const iframe = scope.getByTestId("iframe");
-          expect(iframe).toHaveAttribute("height", "0");
-          expect(iframe).toHaveAttribute("width", "100%");
-        });
-
         it("calls externally bound listener", () => {
           const listener = jest.fn();
 
@@ -315,44 +293,29 @@ describe("Embed", () => {
 
           expect(listener).toHaveBeenCalledWith(data.data);
         });
-      });
-    });
-  });
 
-  describe("with `matchContentsHeight` enabled", () => {
-    beforeEach(() => {
-      jest.clearAllMocks();
-
-      element = window.document.createElement("div");
-
-      embed = new Embed({
-        element,
-        loaderClass: "theClass",
-        matchContentsHeight: true,
-        url: "https://www.example.com/",
-      });
-    });
-
-    it("sets the height of the iframe", () => {
-      fireEvent(
-        window,
-        new MessageEvent("message", {
-          data: {
-            kind: MESSAGE_KIND.WINDOW_DIMENSION_CHANGE,
-            data: {
-              bounds: {
-                height: 200,
+        it("sets the height of the iframe", () => {
+          fireEvent(
+            window,
+            new MessageEvent("message", {
+              data: {
+                kind: MESSAGE_KIND.WINDOW_DIMENSION_CHANGE,
+                data: {
+                  bounds: {
+                    height: 200,
+                  },
+                },
               },
-            },
-          },
-          origin: "https://api.superapi.com.au",
-        }),
-      );
+              origin: "https://api.superapi.com.au",
+            }),
+          );
 
-      const scope = within(element);
-      const iframe = scope.getByTestId("iframe");
-      expect(iframe).toHaveAttribute("height", "200px");
-      expect(iframe).toHaveAttribute("width", "100%");
+          const scope = within(element);
+          const iframe = scope.getByTestId("iframe");
+          expect(iframe).toHaveAttribute("height", "200px");
+          expect(iframe).toHaveAttribute("width", "100%");
+        });
+      });
     });
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,6 @@ export type Options = {
   element: HTMLElement;
   extraAllowedOrigins?: Array<string>;
   loaderClass?: string;
-  matchContentsHeight?: boolean;
   url: string;
 };
 
@@ -90,13 +89,7 @@ export class Embed {
   allowedOrigins: Array<string>;
 
   constructor(options: Options) {
-    // Merge options over the top of the default options
-    this.options = {
-      ...{
-        matchContentsHeight: false,
-      },
-      ...options,
-    };
+    this.options = options;
 
     log.info(`Creating embed wrapper on element with URL: ${this.options.url}`);
 
@@ -216,9 +209,7 @@ export class Embed {
           `Reacting to dimensions change of iFrame element, setting height to ${height}`,
         );
 
-        if (this.options.matchContentsHeight === true) {
-          this.iframe.height = `${height}px`;
-        }
+        this.iframe.height = `${height}px`;
 
         this.bus.emit(event.data.kind, event.data.data);
 


### PR DESCRIPTION
This change will now automatically implement the `matchContentHeight` option, it ensures that the height of the iFrame will always expand to match the contents that are inside it.

BREAKING CHANGE: If you were previously manually setting the height of the iFrame, this will now be ignored.