### PR TITLE
fix(layout): fix race condition on height

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -74,7 +74,6 @@ describe("Embed", () => {
         const scope = within(element);
         const iframe = scope.getByTestId("iframe");
         fireEvent(iframe, new Event("load"));
-        expect(iframe).toHaveAttribute("height", "100%");
       });
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,7 +115,6 @@ export class Embed {
     this.iframe.setAttribute("data-testid", "iframe");
     this.iframe.addEventListener("load", () => {
       this.loader.remove();
-      this.iframe.height = "100%";
     });
 
     // Setup the loader element, this is displayed before the iFrame is ready


### PR DESCRIPTION
This fixes a bug where the loaded even would sometimes fire after a dimensions change event, this would override the height of the embed to 100%. This change removes any setting of the height after the embed has loaded, instead we rely on the height coming from the embed itself.
