### PR TITLE
feat(iframe tag): allow fullscreen on iFrame tag

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -127,6 +127,7 @@ export class Embed {
     this.iframe.width = "100%";
     this.iframe.height = "0";
     this.iframe.setAttribute("data-testid", "iframe");
+    this.iframe.allow = "fullscreen";
 
     // Setup the loader element, this is displayed before the iFrame is ready
     this.loader = window.document.createElement("div");


### PR DESCRIPTION
To support showing instructional videos inside the embed, we have added an attribute to allow fullscreen display of the contents of the iFrame.