### PR TITLE
Remove remote ID from MFA payload and update types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -66,15 +66,15 @@ export type AvailableMessages =
   | WindowDimensionChangeMessageV1;
 
 export type MessageKindToTypeMap = {
-  [MESSAGE_KIND.EMPLOYER_SETTINGS_COMMITTED]: EmployerSettingsCommittedMessageV1;
-  [MESSAGE_KIND.EMPLOYER_SETTINGS_UPDATED]: EmployerSettingsUpdatedMessageV1;
-  [MESSAGE_KIND.LOADED]: LoadedMessageV1;
-  [MESSAGE_KIND.MFA_VERIFICATION_COMPLETED]: MfaVerificationCompleteMessageV1;
-  [MESSAGE_KIND.ONBOARDING_SESSION_COMMITTED]: OnboardingSessionCommittedMessageV1;
-  [MESSAGE_KIND.ONBOARDING_SESSION_FINISHED]: OnboardingSessionFinishedMessageV1;
-  [MESSAGE_KIND.ONBOARDING_STEP_CHANGED]: OnboardingStepChangedMessageV1;
-  [MESSAGE_KIND.TOAST]: ToastMessageV1;
-  [MESSAGE_KIND.WINDOW_DIMENSION_CHANGE]: WindowDimensionChangeMessageV1;
+  [MESSAGE_KIND.EMPLOYER_SETTINGS_COMMITTED]: EmployerSettingsCommittedDataV1;
+  [MESSAGE_KIND.EMPLOYER_SETTINGS_UPDATED]: EmployerSettingsUpdatedDataV1;
+  [MESSAGE_KIND.LOADED]: null;
+  [MESSAGE_KIND.MFA_VERIFICATION_COMPLETED]: MfaVerificationCompleteDataV1;
+  [MESSAGE_KIND.ONBOARDING_SESSION_COMMITTED]: OnboardingSessionCommittedDataV1;
+  [MESSAGE_KIND.ONBOARDING_SESSION_FINISHED]: OnboardingSessionFinishedDataV1;
+  [MESSAGE_KIND.ONBOARDING_STEP_CHANGED]: OnboardingStepChangedDataV1;
+  [MESSAGE_KIND.TOAST]: ToastMessageDataV1;
+  [MESSAGE_KIND.WINDOW_DIMENSION_CHANGE]: WindowDimensionChangeMessageDataV1;
 };
 
 // What origins are we allowed to receive messages from

--- a/src/services/messages/v1/mfa_verification_complete.ts
+++ b/src/services/messages/v1/mfa_verification_complete.ts
@@ -11,7 +11,7 @@ export type Data = {
 /**
  * A message type emitted when the user has either completed their MFA session or
  * have exceeded the maximum number of attempts. Successful attempts will have their
- * `verfied_at` property as an ISO-8601 string, while failed attempts will be `null`.
+ * `verified_at` property as an ISO-8601 string, while failed attempts will be `null`.
  */
 export type Message = {
   data: Data;

--- a/src/services/messages/v1/mfa_verification_complete.ts
+++ b/src/services/messages/v1/mfa_verification_complete.ts
@@ -1,10 +1,18 @@
 import { MESSAGE_KIND } from "../../messages";
 
 export type Data = {
+  /**
+   * A ISO 8601 compliant date time string indicating when the MFA session was
+   * verified. This will be `null` when verifications attempts have been exceeded.
+   */
   verified_at: string | null;
-  remote_id: string | null;
 };
 
+/**
+ * A message type emitted when the user has either completed their MFA session or
+ * have exceeded the maximum number of attempts. Successful attempts will have their
+ * `verfied_at` property as an ISO-8601 string, while failed attempts will be `null`.
+ */
 export type Message = {
   data: Data;
   kind: MESSAGE_KIND.MFA_VERIFICATION_COMPLETED;


### PR DESCRIPTION
BREAKING CHANGE: Removes the remote ID from the MFA payload and updates the callback types

## Description of the changes

- Remove the `remote_id` from the MFA payload
