### PR TITLE
Add custom loader element

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The `Embed` class can be invoked with the following parameters:
 | loaderClass         | An optional class that can be added to the loader element which is shown when the embed is initializing. Use this to customise the loader.    | No       | `.myLoader`                                |
 | onLoadError         | An optional callback that will fire if the embed cannot load SuperAPI due to an error                                                         | No       | `() => { console.log('Error detected!') }` |
 | url                 | The SuperAPI URL that has been signed, this will then be loaded                                                                               | Yes      | `https://example.com`                      |
+| createLoader        | A function that creates the element which is shown when loading the iFrame                                                                    | No       | `() => document.createElement("div");`     |
 
 Once the loader has been setup you can then interact with returned instance of the embed.
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -430,6 +430,26 @@ describe("Embed", () => {
     });
   });
 
+  describe("can provide custom loaders", () => {
+    it("creates the custom loader when provided", () => {
+      const spy = jest.fn();
+
+      const element = window.document.createElement("div");
+
+      new Embed({
+        element,
+        loaderClass: "theClass",
+        url: "https://www.example.com/",
+        createLoader: () => {
+          spy();
+          return window.document.createElement("div");
+        },
+      });
+
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+
   describe("can provide additional origins", () => {
     beforeEach(() => {
       jest.clearAllMocks();

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -432,21 +432,23 @@ describe("Embed", () => {
 
   describe("can provide custom loaders", () => {
     it("creates the custom loader when provided", () => {
-      const spy = jest.fn();
-
-      const element = window.document.createElement("div");
+      const container = window.document.createElement("div");
 
       new Embed({
-        element,
-        loaderClass: "theClass",
+        element: container,
+        loaderClass: "loading-class",
         url: "https://www.example.com/",
         createLoader: () => {
-          spy();
-          return window.document.createElement("div");
+          const loader = window.document.createElement("div");
+          loader.innerHTML = "<span>Custom Loading</span>";
+          return loader;
         },
       });
 
-      expect(spy).toHaveBeenCalled();
+      const loaderEl = container.querySelector(`[data-testid="loader"]`);
+      expect(loaderEl).toBeInstanceOf(HTMLDivElement);
+      expect(loaderEl?.classList.contains("loading-class")).toBe(true);
+      expect(loaderEl?.innerHTML).toContain("Custom Loading");
     });
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,6 +92,7 @@ const defaultAllowedOrigins = ["https://api.superapi.com.au"];
 export type Options = {
   element: HTMLElement;
   extraAllowedOrigins?: Array<string>;
+  createLoader?: () => HTMLDivElement;
   loaderClass?: string;
   onLoadError?: () => void;
   url: string;
@@ -170,9 +171,19 @@ export class Embed {
     });
 
     // Setup the loader element, this is displayed before the iFrame is ready
-    this.loader = window.document.createElement("div");
-    this.loader.setAttribute("data-testid", "loader");
-    this.loader.innerHTML = "Loading...";
+    // Partners can provide a function that creates the loading element, so they
+    // can create their own cards.
+    const loader = options.createLoader
+      ? options.createLoader()
+      : window.document.createElement("div");
+
+    loader.setAttribute("data-testid", "loader");
+
+    if (!options.createLoader) {
+      loader.innerHTML = "Loading...";
+    }
+
+    this.loader = loader;
 
     if (this.options.loaderClass) {
       this.loader.classList.add(this.options.loaderClass);


### PR DESCRIPTION
Adds a callback that can be invoked to show an intermediary loading state instead of a just "Loading". Below is an example of utilising this functionality to load a card skeleton on XOnboard.

https://github.com/user-attachments/assets/9f6e021d-f7f0-4c23-9109-e059a06d9741

 