### PR TITLE
fix(iframe resizing): improve positioning of the iFrame after events

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -434,6 +434,70 @@ describe("Embed", () => {
           expect(iframe).toHaveAttribute("width", "100%");
         });
       });
+
+      describe("page loaded event", () => {
+        beforeEach(() => {
+          Element.prototype.scrollIntoView = jest.fn();
+        });
+
+        it("logs the event", () => {
+          fireEvent(
+            window,
+            new MessageEvent("message", {
+              data: {
+                kind: MESSAGE_KIND.PAGE_LOADED,
+                data: null,
+              },
+              origin: "https://api.superapi.com.au",
+            }),
+          );
+
+          // eslint-disable-next-line @typescript-eslint/unbound-method
+          expect(loglevel.debug).toHaveBeenCalledWith(
+            "Reacting to page load, scrolling iFrame into view",
+          );
+        });
+
+        it("calls externally bound listener", () => {
+          const listener = jest.fn();
+
+          const data = {
+            kind: MESSAGE_KIND.PAGE_LOADED,
+            data: null,
+          };
+
+          embed.on(MESSAGE_KIND.PAGE_LOADED, listener);
+
+          fireEvent(
+            window,
+            new MessageEvent("message", {
+              data,
+              origin: "https://api.superapi.com.au",
+            }),
+          );
+
+          expect(listener).toHaveBeenCalledWith(data.data);
+        });
+
+        it("scrolls the iframe into view", () => {
+          fireEvent(
+            window,
+            new MessageEvent("message", {
+              data: {
+                kind: MESSAGE_KIND.PAGE_LOADED,
+                data: null,
+              },
+              origin: "https://api.superapi.com.au",
+            }),
+          );
+
+          // eslint-disable-next-line @typescript-eslint/unbound-method
+          expect(Element.prototype.scrollIntoView).toHaveBeenCalledWith({
+            behavior: "instant",
+            block: "start",
+          });
+        });
+      });
     });
   });
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -62,6 +62,13 @@ describe("Embed", () => {
         expect(iframe).toHaveAttribute("width", "100%");
       });
 
+      it("disables scrolling on the iframe", () => {
+        const scope = within(element);
+        const iframe = scope.getByTestId("iframe");
+        expect(iframe).toHaveAttribute("scrolling", "no");
+        expect(iframe).toHaveStyle({ overflow: "hidden" });
+      });
+
       it("removes the loader element when the load event fires", () => {
         const scope = within(element);
         const loader = scope.getByTestId("loader");

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,10 @@ import type {
   Message as OnboardingStepChangedMessageV1,
 } from "./services/messages/v1/onboarding_step_changed";
 import type {
+  Data as PageLoadedDataV1,
+  Message as PageLoadedMessageV1,
+} from "./services/messages/v1/page_loaded";
+import type {
   Data as ToastMessageDataV1,
   Kind as ToastKindV1,
   Message as ToastMessageV1,
@@ -55,6 +59,7 @@ export {
 };
 export { OnboardingSessionFinishedDataV1, OnboardingSessionFinishedMessageV1 };
 export { OnboardingStepChangedDataV1, OnboardingStepChangedMessageV1 };
+export { PageLoadedDataV1, PageLoadedMessageV1 };
 export { ToastKindV1, ToastMessageDataV1, ToastMessageV1 };
 export { LoadedMessageDataV1, LoadedMessageV1 };
 export { WindowDimensionChangeMessageDataV1, WindowDimensionChangeMessageV1 };
@@ -68,6 +73,7 @@ export type AvailableMessages =
   | OnboardingSessionCommittedMessageV1
   | OnboardingSessionFinishedMessageV1
   | OnboardingStepChangedMessageV1
+  | PageLoadedMessageV1
   | ToastMessageV1
   | WindowDimensionChangeMessageV1;
 
@@ -80,6 +86,7 @@ export type MessageKindToTypeMap = {
   [MESSAGE_KIND.ONBOARDING_SESSION_COMMITTED]: OnboardingSessionCommittedDataV1;
   [MESSAGE_KIND.ONBOARDING_SESSION_FINISHED]: OnboardingSessionFinishedDataV1;
   [MESSAGE_KIND.ONBOARDING_STEP_CHANGED]: OnboardingStepChangedDataV1;
+  [MESSAGE_KIND.PAGE_LOADED]: PageLoadedDataV1;
   [MESSAGE_KIND.TOAST]: ToastMessageDataV1;
   [MESSAGE_KIND.WINDOW_DIMENSION_CHANGE]: WindowDimensionChangeMessageDataV1;
 };
@@ -289,6 +296,16 @@ export class Embed {
         break;
       }
 
+      case MESSAGE_KIND.PAGE_LOADED: {
+        log.debug("Reacting to page load, scrolling iFrame into view");
+
+        this.iframe.scrollIntoView({ behavior: "instant", block: "start" });
+
+        this.bus.emit(event.data.kind, event.data.data);
+
+        break;
+      }
+
       case MESSAGE_KIND.TOAST: {
         this.bus.emit(event.data.kind, event.data.data);
         break;
@@ -302,9 +319,7 @@ export class Embed {
         );
 
         this.iframe.height = `${height}px`;
-
         this.bus.emit(event.data.kind, event.data.data);
-
         break;
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -152,6 +152,8 @@ export class Embed {
     this.iframe.width = "100%";
     this.iframe.height = "0";
     this.iframe.setAttribute("data-testid", "iframe");
+    this.iframe.setAttribute("scrolling", "no");
+    this.iframe.style.overflow = "hidden";
     this.iframe.allow = "fullscreen";
 
     this.iframe.addEventListener("load", () => {

--- a/src/services/messages.ts
+++ b/src/services/messages.ts
@@ -7,6 +7,7 @@ export enum MESSAGE_KIND {
   ONBOARDING_SESSION_COMMITTED = "onboardingSessionCommitted",
   ONBOARDING_STEP_CHANGED = "onboardingStepChanged",
   ONBOARDING_SESSION_FINISHED = "onboardingSessionFinished",
+  PAGE_LOADED = "pageLoaded",
   TOAST = "toast",
   WINDOW_DIMENSION_CHANGE = "windowDimensionChange",
 }

--- a/src/services/messages/v1/page_loaded.ts
+++ b/src/services/messages/v1/page_loaded.ts
@@ -1,0 +1,9 @@
+import { MESSAGE_KIND } from "../../messages";
+
+export type Data = null;
+
+export type Message = {
+  data: Data;
+  kind: MESSAGE_KIND.PAGE_LOADED;
+  version: "v1";
+};


### PR DESCRIPTION
The iFrame component has a natural scrollbar built into it. Currently, this is never seen because the upstream "resize" event broadcasts are handled without any delay. However, to fix a problem with transiant small heigh pages, the scrolling needs to be disabled to avoid showing a flash of scrollbar content.