### PR TITLE
feat(positioning): position in the center of iFrame instead

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -569,7 +569,11 @@ describe("Embed", () => {
           });
         });
 
-        it("applies a negative scrollMarginTop on the iframe for the scrollIntoView call", () => {
+        it("applies a scrollMarginTop that centers the offset in the viewport", () => {
+          const scope = within(element);
+          const iframe = scope.getByTestId("iframe");
+          const iframeHeight = iframe.getBoundingClientRect().height;
+
           fireEvent(
             window,
             new MessageEvent("message", {
@@ -581,7 +585,7 @@ describe("Embed", () => {
             }),
           );
 
-          expect(scrollMarginAtCallTime).toBe("-240px");
+          expect(scrollMarginAtCallTime).toBe(`${iframeHeight - 2 * 240}px`);
         });
 
         it("restores the iframe scrollMarginTop after scrolling", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -320,8 +320,9 @@ export class Embed {
           `Reacting to scroll into view, scrolling host to iFrame offset ${offsetTop}`,
         );
 
+        const iframeHeight = this.iframe.getBoundingClientRect().height;
         const previousScrollMargin = this.iframe.style.scrollMarginTop;
-        this.iframe.style.scrollMarginTop = `-${offsetTop}px`;
+        this.iframe.style.scrollMarginTop = `${iframeHeight - 2 * offsetTop}px`;
         this.iframe.scrollIntoView({ behavior: "smooth", block: "center" });
         this.iframe.style.scrollMarginTop = previousScrollMargin;
 


### PR DESCRIPTION
Updates the positioning logic to position the scroll in the middle of the iFrame rather than the top.